### PR TITLE
quick sort implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ main(int argc, const char * argv[]) {
 - [x] hash-table
    - [x] builtin hash functions e.g. djb2
    - [x] resizing hash table
+- [x] quick sort implementation for float, double, i32, u32, i64, u64
 - [ ] queue (working on this)
 - [ ] stack
 - [ ] binary heap / priority queue

--- a/include/ds/sort.h
+++ b/include/ds/sort.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ */
+
+#ifndef ds_sort_h
+#define ds_sort_h
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "common.h"
+#include <stdbool.h>
+
+typedef void (*DsSortSwapFunc)(void * __restrict arr,
+                               uint32_t          indexA,
+                               uint32_t          indexB);
+
+#define DS_DEFINE_SORT(POSTFIX, TYPE)                                         \
+  DS_EXPORT                                                                   \
+  void                                                                        \
+  sort ## POSTFIX(TYPE * __restrict arr,                                      \
+                  uint32_t          count);                                   \
+                                                                              \
+  DS_EXPORT                                                                   \
+  void                                                                        \
+  sort ## POSTFIX ## _ex(TYPE * __restrict arr,                               \
+                         uint32_t          count,                             \
+                         bool              asc,                               \
+                         DsSortSwapFunc    swapCb);
+
+DS_DEFINE_SORT(f,   float)
+DS_DEFINE_SORT(d,   double)
+DS_DEFINE_SORT(i,   int32_t)
+DS_DEFINE_SORT(u,   uint32_t)
+DS_DEFINE_SORT(i64, int64_t)
+DS_DEFINE_SORT(u64, uint64_t)
+
+#endif /* ds_sort_h */

--- a/include/ds/sort.h
+++ b/include/ds/sort.h
@@ -29,6 +29,24 @@ typedef void (*DsSortSwapFunc)(void * __restrict arr,
                          bool              asc,                               \
                          DsSortSwapFunc    swapCb);
 
+/*
+ these macros defines functions declerations.
+
+ for instance DS_DEFINE_SORT(f, float) defines functions for float like below:
+
+ DS_EXPORT
+ void
+ sortf(float * __restrict arr,
+       uint32_t           count);
+
+ DS_EXPORT
+ void
+ sortf_ex(float * __restrict arr,
+          uint32_t           count,
+          bool               asc,
+          DsSortSwapFunc     swapCb);
+ */
+
 DS_DEFINE_SORT(f,   float)
 DS_DEFINE_SORT(d,   double)
 DS_DEFINE_SORT(i,   int32_t)
@@ -36,4 +54,6 @@ DS_DEFINE_SORT(u,   uint32_t)
 DS_DEFINE_SORT(i64, int64_t)
 DS_DEFINE_SORT(u64, uint64_t)
 
+#undef DS_DEFINE_SORT
+  
 #endif /* ds_sort_h */

--- a/makefile.am
+++ b/makefile.am
@@ -41,7 +41,8 @@ ds_HEADERS = include/ds/rb.h \
              include/ds/forward-list.h \
              include/ds/forward-list-sep.h \
              include/ds/hash.h \
-             include/ds/hash-funcs.h
+             include/ds/hash-funcs.h \
+             include/ds/sort.h
 
 libds_la_SOURCES=\
     src/default/default.c \
@@ -51,7 +52,8 @@ libds_la_SOURCES=\
     src/forward_list.c \
     src/flist_separate.c \
     src/hash_table.c \
-    src/hash_funcs.c
+    src/hash_funcs.c \
+    src/sort/sort.c
 
 test_tests_SOURCES=\
     test/src/test_common.c \

--- a/src/common.h
+++ b/src/common.h
@@ -17,4 +17,22 @@
 #include <string.h>
 #include <stdio.h>
 
+#define swap(a, b)                                                            \
+  do {                                                                        \
+    typeof(a) t;                                                              \
+    t = a;                                                                    \
+    a = b;                                                                    \
+    b = t;                                                                    \
+  } while(0)
+
+#define swap2(t, a, b)                                                        \
+  do {                                                                        \
+    t = a;                                                                    \
+    a = b;                                                                    \
+    b = t;                                                                    \
+  } while(0)
+
+#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+
 #endif /* ds_src_common_h */

--- a/src/hash_funcs.c
+++ b/src/hash_funcs.c
@@ -64,11 +64,11 @@ ds_hashfn_i32(void *key) {
 DS_EXPORT
 uint32_t
 ds_hashfn_i32p(void *key) {
-  return (int32_t)key;
+  return (int32_t)(intptr_t)key;
 }
 
 DS_EXPORT
 uint32_t
 ds_hashfn_ui32p(void *key) {
-  return (uint32_t)key;
+  return (uint32_t)(uintptr_t)key;
 }

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -152,7 +152,7 @@ hash_insert(HTable     *htable,
     htable->table[idx] = item;
   }
 
-  /* there is no need to access array (read + write),
+  /* there is no need to access buffer (read + write),
    just append it */
   else {
     prev->next = item;
@@ -190,7 +190,7 @@ hash_set(HTable *htable,
     htable->table[idx] = item;
   }
 
-  /* there is no need to access array (read + write),
+  /* there is no need to access buffer (read + write),
      just append it */
   else {
     prev->next = item;

--- a/src/sort/sort.c
+++ b/src/sort/sort.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ */
+
+#include "sort_common.h"
+
+DEFINE_SORT(f, float)
+DEFINE_SORT(d, double)
+DEFINE_SORT(i, int32_t)
+DEFINE_SORT(u, uint32_t)
+DEFINE_SORT(i64, int64_t)
+DEFINE_SORT(u64, uint64_t)

--- a/src/sort/sort_common.h
+++ b/src/sort/sort_common.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c), Recep Aslantas.
+ * MIT License (MIT), http://opensource.org/licenses/MIT
+ */
+
+#ifndef sort_common_h
+#define sort_common_h
+
+#include "../common.h"
+#include "../../include/ds/sort.h"
+
+#define partition(p, TYPE, op1, op2)                                          \
+  do {                                                                        \
+    uint32_t i, j;                                                            \
+    TYPE     tmp, PIVOT;                                                      \
+                                                                              \
+    PIVOT = A[lo];                                                            \
+    i     = lo - 1;                                                           \
+    j     = hi + 1;                                                           \
+                                                                              \
+    for (;;) {                                                                \
+      do {                                                                    \
+        i++;                                                                  \
+      } while (A[i] op1 PIVOT);                                               \
+                                                                              \
+      do {                                                                    \
+        j--;                                                                  \
+      } while (A[j] op2 PIVOT);                                               \
+                                                                              \
+      if (i >= j) {                                                           \
+        p = j;                                                                \
+        break;                                                                \
+      }                                                                       \
+                                                                              \
+      swap2(tmp, A[i], A[j]);                                                 \
+    }                                                                         \
+  } while(0)                                                                  \
+
+#define partition_cb(p, TYPE, op1, op2)                                       \
+  do {                                                                        \
+    uint32_t i, j;                                                            \
+    TYPE     tmp, PIVOT;                                                      \
+                                                                              \
+    PIVOT = A[lo];                                                            \
+    i     = lo - 1;                                                           \
+    j     = hi + 1;                                                           \
+                                                                              \
+    for (;;) {                                                                \
+      do {                                                                    \
+        i++;                                                                  \
+      } while (A[i] op1 PIVOT);                                               \
+                                                                              \
+      do {                                                                    \
+        j--;                                                                  \
+      } while (A[j] op2 PIVOT);                                               \
+                                                                              \
+      if (i >= j) {                                                           \
+        p = j;                                                                \
+        break;                                                                \
+      }                                                                       \
+                                                                              \
+      swap2(tmp, A[i], A[j]);                                                 \
+      cb(A, i, j);                                                            \
+    }                                                                         \
+  } while(0)                                                                  \
+
+#define partition_asc(TYPE, PIVOT)                                            \
+  partition(PIVOT, TYPE, <, >)
+#define partition_dsc(TYPE, PIVOT)                                            \
+  partition(PIVOT, TYPE, >, <)
+#define partition_asc_cb(TYPE, PIVOT)                                         \
+  partition_cb(PIVOT, TYPE, <, >)
+#define partition_dsc_cb(TYPE, PIVOT)                                         \
+  partition_cb(PIVOT, TYPE, >, <)
+
+#define DEFINE_SORT_FUNC(POSTFIX, TYPE, ORDER)                                \
+  static                                                                      \
+  void                                                                        \
+  sort ## POSTFIX ## _ ## ORDER(TYPE * __restrict A,                          \
+                                uint32_t lo,                                  \
+                                uint32_t hi) {                                \
+    uint32_t p;                                                               \
+                                                                              \
+    if (lo < hi) {                                                            \
+      partition_ ## ORDER(TYPE, p);                                           \
+      sort ## POSTFIX ## _ ## ORDER(A, lo, p);                                \
+      sort ## POSTFIX ## _ ## ORDER(A, p + 1, hi);                            \
+    }                                                                         \
+  }                                                                           \
+                                                                              \
+  static                                                                      \
+  void                                                                        \
+  sort ## POSTFIX ## _ ## ORDER ## _cb(TYPE * __restrict A,                   \
+                                       DsSortSwapFunc    cb,                  \
+                                       uint32_t          lo,                  \
+                                       uint32_t          hi) {                \
+    uint32_t p;                                                               \
+                                                                              \
+    if (lo < hi) {                                                            \
+      partition_ ## ORDER ## _cb(TYPE, p);                                    \
+      sort ## POSTFIX ## _ ## ORDER ## _cb(A, cb, lo, p);                     \
+      sort ## POSTFIX ## _ ## ORDER ## _cb(A, cb, p + 1, hi);                 \
+    }                                                                         \
+  }
+
+#define DEFINE_FUNC(POSTFIX, TYPE)                                            \
+  DS_EXPORT                                                                   \
+  void                                                                        \
+  sort ## POSTFIX(TYPE  * __restrict arr,                                     \
+        uint32_t            count) {                                          \
+    sort ## POSTFIX ## _asc(arr, 0, count - 1);                               \
+  }                                                                           \
+                                                                              \
+  DS_EXPORT                                                                   \
+  void                                                                        \
+  sort ## POSTFIX ## _ex(TYPE * __restrict arr,                               \
+                         uint32_t          count,                             \
+                         bool              asc,                               \
+                         DsSortSwapFunc    swapCb) {                          \
+    if (!swapCb) {                                                            \
+      if (asc)                                                                \
+        sort ## POSTFIX ## _asc(arr, 0, count - 1);                           \
+      else                                                                    \
+        sort ## POSTFIX ## _dsc(arr, 0, count - 1);                           \
+      return;                                                                 \
+    }                                                                         \
+                                                                              \
+    if (asc)                                                                  \
+      sort ## POSTFIX ## _asc_cb(arr, swapCb, 0, count - 1);                  \
+    else                                                                      \
+      sort ## POSTFIX ## _dsc_cb(arr, swapCb, 0, count - 1);                  \
+  }
+
+#define DEFINE_SORT(POSTFIX, TYPE)                                            \
+  DEFINE_SORT_FUNC(POSTFIX, TYPE, asc)                                        \
+  DEFINE_SORT_FUNC(POSTFIX, TYPE, dsc)                                        \
+  DEFINE_FUNC(POSTFIX, TYPE)
+
+#endif /* sort_common_h */

--- a/win/libds.vcxproj
+++ b/win/libds.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{CA8BCAF9-CD25-4133-8F62-3D1449B5D2FC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libds</RootNamespace>
-		<WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -173,9 +173,11 @@
     <ClInclude Include="..\include\ds\hash.h" />
     <ClInclude Include="..\include\ds\hashtable.h" />
     <ClInclude Include="..\include\ds\rb.h" />
+    <ClInclude Include="..\include\ds\sort.h" />
     <ClInclude Include="..\include\ds\util.h" />
     <ClInclude Include="..\src\common.h" />
     <ClInclude Include="..\src\default\default.h" />
+    <ClInclude Include="..\src\sort\sort_common.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\allocator.c" />
@@ -185,6 +187,7 @@
     <ClCompile Include="..\src\hash_funcs.c" />
     <ClCompile Include="..\src\hash_table.c" />
     <ClCompile Include="..\src\rb.c" />
+    <ClCompile Include="..\src\sort\sort.c" />
     <ClCompile Include="..\src\util.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/win/libds.vcxproj.filters
+++ b/win/libds.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="test\src">
       <UniqueIdentifier>{b9f8b30a-6091-4fb0-96e2-52029459d024}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\sort">
+      <UniqueIdentifier>{bcfd119c-06c3-4c43-b005-4eb4b103513f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\ds\rb.h">
@@ -66,6 +69,12 @@
     <ClInclude Include="..\include\ds\forward-list-sep.h">
       <Filter>include\ds</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\ds\sort.h">
+      <Filter>include\ds</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\sort\sort_common.h">
+      <Filter>src\sort</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\rb.c">
@@ -91,6 +100,9 @@
     </ClCompile>
     <ClCompile Include="..\src\flist_separate.c">
       <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\sort\sort.c">
+      <Filter>src\sort</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Quick sort implementation for **float**, **double**, **int32**, **uint32**, **int64** and **uint64**.

The implementation is specific to primitive types so it must be faster than builtin qsort. Because
- it eliminates compare function
- it eliminates size parameter

Some features:
- clean interface
- it allows both ASC and DESC ordering
- it provides a swap item callback so if you have two or more arrays and you can swap elements in other arrays while the array is being sorted.
- it uses Hoare partition scheme

in the future sorting order data structures especially linked lists may be supported.